### PR TITLE
card_84: adicionando lock no git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.log
 *.pyc
 *.swp
+*.lock
 .DS_Store
 .atom/
 .buildlog/


### PR DESCRIPTION
Adicionando pubspec.lock no arquivo do git ignore para evitar problemas de build