### PR TITLE
card 206 fix combo de cidade

### DIFF
--- a/lib/view/cidade/cidade_view.dart
+++ b/lib/view/cidade/cidade_view.dart
@@ -146,7 +146,7 @@ class _EstadoView extends State<CidadeView>
 
                     return DropdownButtonFormField
                     (
-                        value: selectedItem != 0 ? selectedItem : null,
+                        value: selectedEstado != 0 ? selectedEstado : null,
                         isExpanded: true,
                         hint: const Text('Selecione um estado'),
                         items: items,


### PR DESCRIPTION
Correção na combo de cidade, na qual não era possível mudar o valor ao atualizar item.

Validação ternária é necessária para não travar a combo.