### PR TITLE
Script para ignorar arquivos de build rastreados pelo git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+/linux/**
+/windows/**
+/macos/**
+/android/**
+/ios/**

--- a/resources/git/git-assume-unchanged.sh
+++ b/resources/git/git-assume-unchanged.sh
@@ -1,0 +1,6 @@
+git update-index --assume-unchanged linux/flutter/generated_plugin_registrant.cc
+git update-index --assume-unchanged linux/flutter/generated_plugins.cmake
+git update-index --assume-unchanged macos/Flutter/GeneratedPluginRegistrant.swift
+git update-index --assume-unchanged windows/flutter/generated_plugin_registrant.cc
+git update-index --assume-unchanged windows/flutter/generated_plugins.cmake
+git update-index --assume-unchanged windows/runner/flutter_window.cpp


### PR DESCRIPTION
Esse arquivo realiza o comando "git update-index --assume-unchanged" em arquivos que já são rastreados.
É uma forma simples para que o git pare de mapear esses arquivos, mesmo que eles estejam commitados na tree.